### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -1,4 +1,7 @@
 name: Azure Static Web Apps CI/CD
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kathirt/donationimpacttracker/security/code-scanning/4](https://github.com/kathirt/donationimpacttracker/security/code-scanning/4)

To resolve this issue, we should add the `permissions` key with required granular permissions for the workflow. The best solution is to define it at the workflow root, so all jobs inherit least-privilege settings unless overridden locally. According to best practice and the types of actions used in this workflow, the minimum is typically `contents: read` and `pull-requests: write` (for jobs needing to update PR status, e.g., deployment previews). Reviewing the actions used:
- Both jobs use `Azure/static-web-apps-deploy`, which updates checks and comments on pull requests, so it requires `pull-requests: write`.
- They also read from the repo, so `contents: read` is required.

Add a `permissions` block after the workflow `name` (and before `on:`), with:
```yaml
permissions:
  contents: read
  pull-requests: write
```
No changes are needed within the jobs themselves unless further permissions tuning is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
