### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-ambitious-bush-0efbb460f.yml
+++ b/.github/workflows/azure-static-web-apps-ambitious-bush-0efbb460f.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')


### PR DESCRIPTION
Potential fix for [https://github.com/kathirt/donationimpacttracker/security/code-scanning/3](https://github.com/kathirt/donationimpacttracker/security/code-scanning/3)

To fix the issue, you should declare a `permissions` block at the root of the workflow YAML (recommended to cover all jobs unless a job needs a different scope, in which case you can set per-job `permissions`). The minimal starting point is `permissions: {}` (no permissions), but in this case, since the workflow uses checkout and deployment actions (and, for pull request integrations, may need to post PR comments), the safe defaults are:

- `contents: read` (so it can check out code)
- `pull-requests: write` (for posting PR comments via the deploy action, if needed)

These permissions can be set at the root (top) just after the workflow name and `on:` block, or as restrictive as possible per job as per your needs. Here, adding at the root is simplest and covers both jobs.

Specifically, add a block like:

```yaml
permissions:
  contents: read
  pull-requests: write
```

Just before the `jobs:` block, so between lines 11 and 12.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
